### PR TITLE
Add flag to allow filter options to be passed to varnishstat; Add testcases for varnishstat params

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,6 +55,7 @@ type startParams struct {
 type varnishstatParams struct {
 	Instance string
 	VSM      string
+	Filter   string
 }
 
 func (p *varnishstatParams) isEmpty() bool {
@@ -69,6 +71,14 @@ func (p *varnishstatParams) make() (params []string) {
 	if p.VSM != "" && VarnishVersion.EqualsOrGreater(4, 0) {
 		params = append(params, "-N", p.VSM)
 	}
+
+	// -f
+	if p.Filter != "" {
+		filterArgs := strings.Split(p.Filter, ",")
+		preparedArgs := strings.Join(filterArgs, " -f ")
+		params = append(params, "-f", preparedArgs)
+	}
+
 	return params
 }
 
@@ -82,6 +92,7 @@ func main() {
 	flag.StringVar(&StartParams.VarnishstatExe, "varnishstat-path", StartParams.VarnishstatExe, "Path to varnishstat.")
 	flag.StringVar(&StartParams.Params.Instance, "n", StartParams.Params.Instance, "varnishstat -n value.")
 	flag.StringVar(&StartParams.Params.VSM, "N", StartParams.Params.VSM, "varnishstat -N value.")
+	flag.StringVar(&StartParams.Params.Filter, "f", StartParams.Params.Filter, "Comma separated list of varnishstat -f arguments, expands out to multiple -f arguments to varnishstat")
 
 	// docker
 	flag.StringVar(&StartParams.VarnishDockerContainer, "docker-container-name", StartParams.VarnishDockerContainer, "Docker container name to exec varnishstat in.")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_varnishstatParams_make(t *testing.T) {
+	type fields struct {
+		Instance string
+		VSM      string
+		Filter   string
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		wantParams []string
+	}{
+		{
+			name: "NoFilterFlags",
+			fields: fields{
+				Instance: "",
+				VSM: "",
+				Filter: "",
+			},
+			wantParams: nil,
+		},
+		{
+			name: "FilterFlags",
+			fields: fields{
+				Instance: "",
+				VSM: "",
+				Filter: `^VBE.*\.bereq_hdrbytes,^VBE.*\.bereq_bodybytes,^VBE.*\.beresp_hdrbytes,^VBE.*\.beresp_bodybytes`,
+			},
+			wantParams: []string{"-f", `^VBE.*\.bereq_hdrbytes -f ^VBE.*\.bereq_bodybytes -f ^VBE.*\.beresp_hdrbytes -f ^VBE.*\.beresp_bodybytes`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &varnishstatParams{
+				Instance: tt.fields.Instance,
+				VSM:      tt.fields.VSM,
+				Filter:   tt.fields.Filter,
+			}
+			if gotParams := p.make(); !reflect.DeepEqual(gotParams, tt.wantParams) {
+				t.Errorf("make() = %v, want %v", gotParams, tt.wantParams)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Current Behavior
Exporter performance degrades when a large number of backends are present


## Why do we need this change?
We want to be able to filter out backend metrics from `varnishstat`, providing consistent performance and metric availability regardless of the number of backends present.

## Implementation Details
- Added `-f` flag allowing a comma separated list of filters to be passed to the exporter which will in turn be passed to `varnishstat` on scrape execution.
- Added test, testcases for `varnishstat` params

:house: [sc58193](https://app.clubhouse.io/movableink/story/58193)
