### PR TITLE
Fix missing filter flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,8 +75,9 @@ func (p *varnishstatParams) make() (params []string) {
 	// -f
 	if p.Filter != "" {
 		filterArgs := strings.Split(p.Filter, ",")
-		preparedArgs := strings.Join(filterArgs, " -f ")
-		params = append(params, "-f", preparedArgs)
+		for _, arg := range filterArgs {
+			params = append(params, "-f", arg)
+		}
 	}
 
 	return params

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ type varnishstatParams struct {
 }
 
 func (p *varnishstatParams) isEmpty() bool {
-	return p.Instance == "" && p.VSM == ""
+	return p.Instance == "" && p.VSM == "" && p.Filter == ""
 }
 
 func (p *varnishstatParams) make() (params []string) {


### PR DESCRIPTION
## Current Behavior
- `varnishstat` filter flags are not making it to `varnishstat` calls

## Why do we need this change?
We want to be able to filter out backend metrics from `varnishstat`, providing consistent performance and metric availability regardless of the number of backends present.

## Implementation Details
- Update implementation of `isEmpty()` to check for values in `p.Filter`
- Append parameters properly, concatenating a string does not work properly.

:house: [sc58193](https://app.clubhouse.io/movableink/story/58193)
